### PR TITLE
Remove empty meta description

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title>Resume Nation</title>
-  <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
   <meta name="theme-color" content="#673AB7">
   <meta name="application-name" content="Resume Nation">


### PR DESCRIPTION
This PR is for remove an unnecessary / unused / empty meta description.
There is already one functional meta description in use:
`<meta name="description" content="A resume generator progressive web app">`